### PR TITLE
Fixed bugs in navigator_middleware.dart

### DIFF
--- a/lib/service/navigator_middleware.dart
+++ b/lib/service/navigator_middleware.dart
@@ -12,7 +12,12 @@ class NavigatorMiddleware<R extends Route<dynamic>> extends RouteObserver<R> {
     this.onReplace,
     this.onRemove,
   }) : _stack = [];
+    
+   /// Use of this navigatorKey is optional
+   /// Used to efficiently monitor and react to route changes
+   /// Enables you to implement custom behaviors or perform specific tasks during navigation transitions.
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+    
   final List<R> _stack;
   final bool enableLogger;
   final OnRouteChange<R>? onPush;

--- a/lib/service/navigator_middleware.dart
+++ b/lib/service/navigator_middleware.dart
@@ -1,9 +1,8 @@
 import 'dart:developer';
-
 import 'package:flutter/material.dart';
 
 typedef OnRouteChange<R extends Route<dynamic>> = void Function(
-    R route, R previousRoute);
+    R route, R? previousRoute);
 
 class NavigatorMiddleware<R extends Route<dynamic>> extends RouteObserver<R> {
   NavigatorMiddleware({
@@ -13,42 +12,38 @@ class NavigatorMiddleware<R extends Route<dynamic>> extends RouteObserver<R> {
     this.onReplace,
     this.onRemove,
   }) : _stack = [];
-
+  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
   final List<R> _stack;
   final bool enableLogger;
-
   final OnRouteChange<R>? onPush;
   final OnRouteChange<R>? onPop;
   final OnRouteChange<R>? onReplace;
   final OnRouteChange<R>? onRemove;
-
-  //create clone list from stack
   List<R> get stack => List<R>.from(_stack);
-
   @override
-  void didPush(Route route, Route? previousRoute) {
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     _logger('{didPush} \n route: $route \n previousRoute: $previousRoute');
     _stack.add(route as R);
     _logStack();
     if (onPush != null) {
-      onPush!(route, previousRoute as R);
+      onPush!(route, previousRoute as R?);
     }
     super.didPush(route, previousRoute);
   }
 
   @override
-  void didPop(Route route, Route? previousRoute) {
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     _logger('{didPop} \n route: $route \n previousRoute: $previousRoute');
     _stack.remove(route);
     _logStack();
     if (onPop != null) {
-      onPop!(route as R, previousRoute as R);
+      onPop!(route as R, previousRoute as R?);
     }
     super.didPop(route, previousRoute);
   }
 
   @override
-  void didReplace({Route? newRoute, Route? oldRoute}) {
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
     _logger('{didReplace} \n newRoute: $newRoute \n oldRoute: $oldRoute');
     if (_stack.contains(oldRoute)) {
       final oldItemIndex = _stack.indexOf(oldRoute as R);
@@ -56,24 +51,25 @@ class NavigatorMiddleware<R extends Route<dynamic>> extends RouteObserver<R> {
     }
     _logStack();
     if (onReplace != null) {
-      onReplace!(newRoute as R, oldRoute as R);
+      onReplace!(newRoute as R, oldRoute as R?);
     }
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
   }
 
   @override
-  void didRemove(Route route, Route? previousRoute) {
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
     _logger('{didRemove} \n route: $route \n previousRoute: $previousRoute');
     stack.remove(route);
     _logStack();
     if (onRemove != null) {
-      onRemove!(route as R, previousRoute as R);
+      onRemove!(route as R, previousRoute as R?);
     }
     super.didRemove(route, previousRoute);
   }
 
   @override
-  void didStartUserGesture(Route route, Route? previousRoute) {
+  void didStartUserGesture(
+      Route<dynamic> route, Route<dynamic>? previousRoute) {
     _logger(
         '{didStartUserGesture} \n route: $route \n previousRoute: $previousRoute');
     super.didStartUserGesture(route, previousRoute);
@@ -88,7 +84,6 @@ class NavigatorMiddleware<R extends Route<dynamic>> extends RouteObserver<R> {
   void _logStack() {
     final mappedStack =
         _stack.map((Route route) => route.settings.name).toList();
-
     _logger('Navigator stack: $mappedStack');
   }
 


### PR DESCRIPTION
Fixed: Null cannot be a subtype of Route<dynamic> in type cast

Fixed: A GlobalKey<NavigationState> was used multiple times inside one widget's child list